### PR TITLE
use signal.pause() to avoid using 100% CPU

### DIFF
--- a/code/musicbox.py
+++ b/code/musicbox.py
@@ -1,5 +1,6 @@
 import pygame.mixer
 import RPi.GPIO as GPIO
+import signal
 
 pygame.mixer.init()
 
@@ -30,4 +31,5 @@ for pin in sound_pins:
 print("ready")
 
 while True:
+    signal.pause()
     pass


### PR DESCRIPTION
signal.pause() causes the process to sleep until a signal is delivered that either terminates the process or causes the invocation of a signal-catching function. That way we avoid the CPU hog effect caused by endless while True sentence.